### PR TITLE
fix: package CRDs apart of the cchart CI process

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -40,6 +40,11 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: Package CRDs
+        shell: bash
+        run: |
+          cp cmd/k8s-operator/deploy/crds cmd/k8s-operator/deploy/chart
+
       - name: Package & Push Helm Charts
         shell: bash
         run: |


### PR DESCRIPTION
This uses the "native helm" method of managing CRDs. Which should fit our usecase okay.