### PR TITLE
fix(ci): pushlish chart on push events

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -10,6 +10,12 @@ on:
     paths:
       - .github/workflows/publish-chart.yaml
       - "**/*"
+  push:
+    branches:
+      - coreweave
+    paths:
+      - .github/workflows/publish-chart.yaml
+      - "**/*"
 
 jobs:
   publish-charts:


### PR DESCRIPTION
This ensures on push events this CI job runs. It aligns with our container build job.