### PR TITLE
fix(ci): use helm crd directory

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -49,16 +49,7 @@ jobs:
       - name: Package CRDs
         shell: bash
         run: |
-          cat <<EOF > cmd/k8s-operator/deploy/chart/templates/crds.yaml
-          {{- if .Values.installCRDs }}
-          EOF
-          for file in cmd/k8s-operator/deploy/crds/*.yaml; do
-            echo "---" >> cmd/k8s-operator/deploy/chart/templates/crds.yaml
-            cat "$file" >> cmd/k8s-operator/deploy/chart/templates/crds.yaml
-          done
-          cat <<EOF >> cmd/k8s-operator/deploy/chart/templates/crds.yaml
-          {{- end }}
-          EOF
+          cp -r cmd/k8s-operator/deploy/crds cmd/k8s-operator/deploy/chart
 
       - name: Package & Push Helm Charts
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ client/web/build/assets
 
 /gocross
 /dist
+
+.DS_Store


### PR DESCRIPTION
When installing a ProxyClass CR alongside the operator, Helm will only install CRDs first if they are in the `crd` directory