### PR TITLE
fix(chart): generate CRDs, duplicate them

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -55,6 +55,7 @@ jobs:
         shell: bash
         if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
         run: |
+          go run cmd/k8s-operator/generate/main.go helmcrd
           helm package cmd/k8s-operator/deploy/chart --dependency-update --version ${{ env.HELM_VERSION }} --app-version ${{ env.HELM_VERSION }}
           pkg=$(ls tailscale-operator-*.tgz)
           helm push "${pkg}" oci://ghcr.io/${{ github.repository }}/chart

--- a/cmd/k8s-operator/deploy/chart/values.yaml
+++ b/cmd/k8s-operator/deploy/chart/values.yaml
@@ -12,7 +12,7 @@ oauth: {}
 # of chart installation. We do not use Helm's CRD installation mechanism as that
 # does not allow for upgrading CRDs.
 # https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
-installCRDs: true
+installCRDs: false
 
 operatorConfig:
   # ACL tag that operator will be tagged with. Operator must be made owner of


### PR DESCRIPTION
Duplicate CRDs in the `templates` directory, and default toggle them off in values.

Since we also use the `crds` directory to allow installing Custom Resources on initial install, this allows for CRD upgrades with a --set toggle